### PR TITLE
Add Konami code easter egg

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Konami } from "@/components/Konami";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 
@@ -13,6 +14,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
+      <Konami />
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />

--- a/src/components/Konami.tsx
+++ b/src/components/Konami.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+const SEQUENCE = [
+  "ArrowUp",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowLeft",
+  "ArrowRight",
+  "b",
+  "a",
+];
+
+export function Konami() {
+  const [position, setPosition] = useState(0);
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === SEQUENCE[position]) {
+        const next = position + 1;
+        if (next === SEQUENCE.length) {
+          setActive(true);
+          setPosition(0);
+        } else {
+          setPosition(next);
+        }
+      } else {
+        setPosition(0);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [position]);
+
+  if (!active) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 text-white text-4xl cursor-pointer"
+      onClick={() => setActive(false)}
+    >
+      <div className="animate-pulse">✨ Secret Unlocked! ✨</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a small `Konami` component that listens for the classic Konami code
- show a fun overlay when the sequence is entered
- render this component in the app so it's available on every page

## Testing
- `npm run lint` *(fails: react-refresh only-export-components warnings, existing errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f6ca9c3288321a1db29b5da1696ab